### PR TITLE
Added last_seen.js plugin

### DIFF
--- a/plugins/last_seen.js
+++ b/plugins/last_seen.js
@@ -89,11 +89,11 @@ bot.on( "UserDisconnected", function( name, sid ) {
 
 // Command //
 
-bot.registerCommand( "lastseen", function( name, steamID, args ) {
+bot.registerCommand( "lastseen", function( name, steamID, _, arg_str ) {
 
 	db.all( "SELECT user, name, time FROM last_seen WHERE name LIKE ? \
 	  ORDER BY name LIMIT 11",
-	  "%" + args[0] + "%",
+	  "%" + arg_str + "%",
 	  function( err, rows ) {
 
 		if ( err ) {
@@ -102,7 +102,7 @@ bot.registerCommand( "lastseen", function( name, steamID, args ) {
 		}
 
 		if ( rows.length == 0 )
-			return bot.sendMessage( "Nobody found with the name '" + args[0]
+			return bot.sendMessage( "Nobody found with the name '" + arg_str
 			  + "'.");
 
 		var output = "";
@@ -133,9 +133,9 @@ bot.registerCommand( "lastseen", function( name, steamID, args ) {
 
 } );
 
-bot.registerCommand( "lastseenid", function( name, steamID, args ) {
+bot.registerCommand( "lastseenid", function( name, steamID, _, arg_str ) {
 
-	db.get( "SELECT name, time FROM last_seen WHERE user = ?", args[0],
+	db.get( "SELECT name, time FROM last_seen WHERE user = ?", arg_str,
 	  function( err, row ) {
 
 		if ( err ) {
@@ -144,7 +144,7 @@ bot.registerCommand( "lastseenid", function( name, steamID, args ) {
 		}
 
 		if ( !row )
-			return bot.sendMessage( "Nobody found with the id '" + args[0]
+			return bot.sendMessage( "Nobody found with the id '" + arg_str
 			  + "'.");
 
 		bot.sendMessage( getLastSeenMsg( name, row.name, row.time ) );

--- a/plugins/last_seen.js
+++ b/plugins/last_seen.js
@@ -1,5 +1,3 @@
-( function( bot ) {
-
 // Database //
 
 db.run( "CREATE TABLE IF NOT EXISTS last_seen(\
@@ -131,5 +129,3 @@ bot.registerCommand( "lastseen", function( name, steamID, _, arg_str ) {
 	} );
 
 } );
-
-} )( bot );

--- a/plugins/last_seen.js
+++ b/plugins/last_seen.js
@@ -91,9 +91,13 @@ bot.on( "UserDisconnected", function( name, sid ) {
 
 bot.registerCommand( "lastseen", function( name, steamID, _, arg_str ) {
 
-	db.all( "SELECT user, name, time FROM last_seen WHERE name LIKE ? \
+    var _ref;
+
+	db.all( "SELECT user, name, time FROM last_seen \
+	  WHERE name LIKE ? OR user = ? \
 	  ORDER BY name LIMIT 11",
 	  "%" + arg_str + "%",
+	  arg_str,
 	  function( err, rows ) {
 
 		if ( err ) {
@@ -128,26 +132,6 @@ bot.registerCommand( "lastseen", function( name, steamID, _, arg_str ) {
 			}
 
 		bot.sendMessage( output );
-
-	} );
-
-} );
-
-bot.registerCommand( "lastseenid", function( name, steamID, _, arg_str ) {
-
-	db.get( "SELECT name, time FROM last_seen WHERE user = ?", arg_str,
-	  function( err, row ) {
-
-		if ( err ) {
-			console.error( err );
-			return bot.sendMessage( "Error!" );
-		}
-
-		if ( !row )
-			return bot.sendMessage( "Nobody found with the id '" + arg_str
-			  + "'.");
-
-		bot.sendMessage( getLastSeenMsg( name, row.name, row.time ) );
 
 	} );
 

--- a/plugins/last_seen.js
+++ b/plugins/last_seen.js
@@ -1,0 +1,156 @@
+( function( bot ) {
+
+// Database //
+
+db.run( "CREATE TABLE IF NOT EXISTS last_seen(\
+  user INTEGER PRIMARY KEY, \
+  name TEXT, \
+  time TEXT )" );
+
+// Util //
+
+var minute = 60;
+var hour = 60 * 60;
+var day = 60 * 60 * 24;
+var week = 60 * 60 * 24 * 7;
+var month = 60 * 60 * 24 * 30;
+var year = 60 * 60 * 24 * 365
+
+function plur( num, suffix ) {
+	num = Math.floor( num );
+	return num == 1 ? num + suffix : num + suffix + "s";
+}
+
+function niceTimeSpan( seconds ) {
+	if ( seconds > year )
+		return plur( seconds / year, " year" );
+	else if ( seconds > month )
+		return plur( seconds / month, " month" );
+	else if ( seconds > week )
+		return plur( seconds / week, " week" );
+	else if ( seconds > day )
+		return plur( seconds / day, " day" );
+	else if ( seconds > hour )
+		return plur( seconds / hour, " hour" );
+	else if ( seconds > minute )
+		return plur( seconds / minute, " minute" );
+	else
+		return plur( seconds, " second" );
+}
+
+function getLastSeenMsg( name, new_name, time ) {
+	var msg = new_name + " was last seen ";
+	msg += niceTimeSpan( ( new Date() - new Date( time ) ) / 1000 );
+	msg += " ago";
+	if ( name && name != new_name )
+		msg += " as " + name;
+	msg += ".";
+
+	return msg;
+}
+
+// Event //
+
+bot.on( "UserConnected", function( name, sid ) {
+	db.get( "SELECT name, time FROM last_seen WHERE user = ?",
+	  sid,
+	  function( err, row ) {
+
+		if ( !err && row ) {
+			// Visited Before
+
+			bot.sendMessage( getLastSeenMsg( name, row.name, row.time ) );
+
+			db.run( "UPDATE last_seen \
+			  SET time = ?, name = ? WHERE user = ?",
+			  new Date().toString(), name, sid );
+
+		} else {
+			// New friend!
+
+			bot.sendMessage( "Hi " + name + "! Welcome to the chat!" );
+
+			db.run( "INSERT INTO last_seen \
+			  ( user, name, time ) VALUES ( ?, ?, ? )",
+			  sid, name, new Date().toString() );
+
+		}
+
+	} );
+} );
+
+bot.on( "UserDisconnected", function( name, sid ) {
+
+	db.run( "UPDATE last_seen \
+	  SET time = ?, name = ? WHERE user = ?",
+	  new Date().toString(), name, sid );
+
+} );
+
+// Command //
+
+bot.registerCommand( "lastseen", function( name, steamID, args ) {
+
+	db.all( "SELECT user, name, time FROM last_seen WHERE name LIKE ? \
+	  ORDER BY name LIMIT 11",
+	  "%" + args[0] + "%",
+	  function( err, rows ) {
+
+		if ( err ) {
+			console.error( err );
+			return bot.sendMessage( "Error!" );
+		}
+
+		if ( rows.length == 0 )
+			return bot.sendMessage( "Nobody found with the name '" + args[0]
+			  + "'.");
+
+		var output = "";
+
+		if ( rows.length == 11 ) {
+			output += "More than 10 entries! Some entries have been omitted.\n";
+			rows.pop();
+		}
+
+		// This doesn't work properly for some reason
+		// Client.chatRooms seems to be returning some out of date list
+		// So everyone is displayed as "offline"
+
+		for ( var x = 0; x < 10; x++ )
+			if ( rows[x] != null ) {
+				var row = rows[x];
+				var user = row.user.toString();
+
+				if ( bot.Client.chatRooms[ bot.GroupID ][ user ] != null )
+					output += row.name + " is in the chat right now!";
+				else
+					output += getLastSeenMsg( null, row.name, row.time ) + "\n";
+			}
+
+		bot.sendMessage( output );
+
+	} );
+
+} );
+
+bot.registerCommand( "lastseenid", function( name, steamID, args ) {
+
+	db.get( "SELECT name, time FROM last_seen WHERE user = ?", args[0],
+	  function( err, row ) {
+
+		if ( err ) {
+			console.error( err );
+			return bot.sendMessage( "Error!" );
+		}
+
+		if ( !row )
+			return bot.sendMessage( "Nobody found with the id '" + args[0]
+			  + "'.");
+
+		bot.sendMessage( getLastSeenMsg( name, row.name, row.time ) );
+
+	} );
+
+} );
+
+} )( bot );

--- a/plugins/last_seen.js
+++ b/plugins/last_seen.js
@@ -3,7 +3,7 @@
 // Database //
 
 db.run( "CREATE TABLE IF NOT EXISTS last_seen(\
-  user INTEGER PRIMARY KEY, \
+  user TEXT PRIMARY KEY, \
   name TEXT, \
   time TEXT )" );
 
@@ -116,16 +116,11 @@ bot.registerCommand( "lastseen", function( name, steamID, _, arg_str ) {
 			rows.pop();
 		}
 
-		// This doesn't work properly for some reason
-		// Client.chatRooms seems to be returning some out of date list
-		// So everyone is displayed as "offline"
-
 		for ( var x = 0; x < 10; x++ )
 			if ( rows[x] != null ) {
 				var row = rows[x];
-				var user = row.user.toString();
 
-				if ( bot.Client.chatRooms[ bot.GroupID ][ user ] != null )
+				if ( bot.Client.chatRooms[ bot.GroupID ][ row.user ] != null )
 					output += row.name + " is in the chat right now!";
 				else
 					output += getLastSeenMsg( null, row.name, row.time ) + "\n";
@@ -136,5 +131,10 @@ bot.registerCommand( "lastseen", function( name, steamID, _, arg_str ) {
 	} );
 
 } );
+
+bot.registerCommand( "_inchat", function() {
+	for ( k in bot.Client.chatRooms[ bot.GroupID ] )
+		bot.sendMessage( k );
+});
 
 } )( bot );

--- a/plugins/last_seen.js
+++ b/plugins/last_seen.js
@@ -132,9 +132,4 @@ bot.registerCommand( "lastseen", function( name, steamID, _, arg_str ) {
 
 } );
 
-bot.registerCommand( "_inchat", function() {
-	for ( k in bot.Client.chatRooms[ bot.GroupID ] )
-		bot.sendMessage( k );
-});
-
 } )( bot );


### PR DESCRIPTION
Adds some "last seen" stats.

Bot will automatically welcome new people to the chat, and also report how long it's been since we've seen someone if they've visited before. If they had a different name, it will also report their old name.

Couple commands are included:

<del>`.lastseenid`: Looks up when a player was last connected via steamid</del> Use `.lastseen`.
`.lastseen`: Looks up when a player was last connected via name. Accepts SQLite wildcards (`%` and `_`). Limited to 10 results.