### PR TITLE
Misc. Fixes to Bot Core

### DIFF
--- a/lib/bot.js
+++ b/lib/bot.js
@@ -90,7 +90,7 @@ function Bot() {
 
 				break;
 
-			case steam.EChatMemberStateChange.Kicked:
+			case steam.EChatMemberStateChange.Banned:
 
 				if ( target != self.Client.steamID )
 					self.emit( "UserBanned", target_name, target, actor_name, actor );

--- a/lib/bot.js
+++ b/lib/bot.js
@@ -59,8 +59,8 @@ function Bot() {
 		var name = self.Client.users[ user ] && self.Client.users[ user ] . playerName || "Unknown";
 
 		var cmd = msg.match(/^\.(\S+)/); cmd = cmd && cmd[1];
-		var args = msg.indexOf(" ") != -1 && (msg.substr(msg.indexOf(" ") + 1)).split(/\s+/);
-		var argstr = msg.match(/.*?\s(.*)/); argstr = argstr && argstr[1] || "";
+		var args; ( args = msg.split( /\s+/ ) ).shift()
+		var argstr = msg.match( /^\.\S+\s+([\s\S]+)/ ); argstr = argstr && argstr[1] || "";
 
 		if ( !cmd )
 			return self.emit( "Message", name, user, msg );


### PR DESCRIPTION
Fixes `arg_str` not working over newlines for chat commands.
Thanks Javascript for not having a dotall flag for Regexes.

Also fixes the UserBanned event never emitting because copy & paste.