### PR TITLE
Fixed a rare steamid trading bug

### DIFF
--- a/lib/bot.js
+++ b/lib/bot.js
@@ -288,7 +288,7 @@ function Bot() {
 
 	self.Trade.on( "error", function( e ) {
 
-		console.log( e );
+		console.trace( e );
 
 		// Attempt to recover from error
 		self.Client.webLogOn( getWebLogOnHandler( self.SessionID ) );
@@ -310,7 +310,7 @@ function Bot() {
 	self.Trade.on( "end", function( status, getItems ) {
 
 		// This only works for trades without trade offers
-		if ( status === "complete" ) {
+		if ( status === "complete" && self.Trade.tradePartnerSteamID && self.Client.users[ self.Trade.tradePartnerSteamID ] ) {
 
 			getItems( function( items ) {
 
@@ -320,7 +320,6 @@ function Bot() {
 
 				} );
 
-				console.log( "trade end hook: ", items );
 				self.sendMessage( self.Client.users[ self.Trade.tradePartnerSteamID ].playerName + " just donated the following items: " + itemNames.join(", ") );
 
 			} );


### PR DESCRIPTION
Also "fixed" mcd's dumb console.log stuff. That stuff should be added on the server you're developing on, not in the main repository. Console.trace is just like console.log but also prints a stacktrace so reverted that too.

In certain rare cases on my bot, the tradePartnerSteamID would be a false value, so that is now fixed.

More commits to come here once mcd gets online and we can actually debug stuff.