### PR TITLE
Change/upgrade hook system

### DIFF
--- a/plugins/lua.js
+++ b/plugins/lua.js
@@ -168,7 +168,7 @@ function LuaQuote( str ) {
 
 function QueueHook( event, args ) {
 
-	var buf = [ "hook.Call(", LuaQuote( event ) ];
+	var buf = [ "HookCall(", LuaQuote( event ) ];
 
 	if ( args && args.length > 0 ) {
 
@@ -184,7 +184,7 @@ function QueueHook( event, args ) {
 
 	buf.push( ")" );
 
-	QueueCommand( buf.join( "" ), true, true );
+	QueueCommand( buf.join( "" ), false, true );
 
 }
 

--- a/plugins/lua/sand_modules/hook.lua
+++ b/plugins/lua/sand_modules/hook.lua
@@ -4,6 +4,7 @@ local override_callstate = true
 
 local persistHooks = {}
 local hooks = {}
+local fake_gettable = {}
 
 local function Add( event, id, callback )
 
@@ -75,10 +76,6 @@ local function Call( event, ... )
 end
 
 local function GetTable()
-	
-	local before = javascript_call
-	
-	javascript_call = false
 
 	local ret = {}
 
@@ -88,8 +85,6 @@ local function GetTable()
 
 	end
 	
-	javascript_call = before
-
 	return ret
 
 end
@@ -103,6 +98,12 @@ end
 local function CalledFromSandbox()
 	
 	return not javascript_call
+	
+end
+
+local function GetUniqueCallID()
+	
+	return unique_call_id
 	
 end
 

--- a/plugins/lua/sand_modules/hook.lua
+++ b/plugins/lua/sand_modules/hook.lua
@@ -1,4 +1,6 @@
 local persist = true
+local javascript_call = true
+local override_callstate = true
 
 local persistHooks = {}
 local hooks = {}
@@ -38,8 +40,19 @@ local function Remove( event, id )
 end
 
 local function Call( event, ... )
+	
+	local before = javascript_call
+	
+	if not override_callstate then
+		javascript_call = false
+	end
+	
+	override_callstate = false
 
 	if not hooks[ event ] then
+		
+		javascript_call = before
+		
 		return
 	end
 
@@ -56,10 +69,16 @@ local function Call( event, ... )
 		end
 
 	end
+	
+	javascript_call = before
 
 end
 
 local function GetTable()
+	
+	local before = javascript_call
+	
+	javascript_call = false
 
 	local ret = {}
 
@@ -68,6 +87,8 @@ local function GetTable()
 		ret[ k ] = v
 
 	end
+	
+	javascript_call = before
 
 	return ret
 
@@ -79,11 +100,32 @@ local function StopPersist()
 
 end
 
+local function CalledFromSandbox()
+	
+	return not javascript_call
+	
+end
+
+-- called from javascript
+
+function HookCall( event, ... )
+	
+	override_callstate = true
+	
+	javascript_call = true
+	
+	Call ( event, ... )
+	
+	javascript_call = false
+	
+end
+
 return {
 	Add = Add,
 	Remove = Remove,
 	RemoveAll = RemoveAll,
 	Call = Call,
 	GetTable = GetTable,
-	StopPersist = StopPersist
+	StopPersist = StopPersist,
+	CalledFromSandbox = CalledFromSandbox,
 }


### PR DESCRIPTION
Some major changes:
`hook.GetTable` returns a fake table full of tables with __eq and such so we can have a special hook function..
`hook.CalledFromSandbox` returns a bool of if the hook function was called from sandbox state or from real state

hooks are called from the real state