### PR TITLE
change hook.GetTable()

### DIFF
--- a/plugins/lua/sand_modules/hook.lua
+++ b/plugins/lua/sand_modules/hook.lua
@@ -4,7 +4,6 @@ local override_callstate = true
 
 local persistHooks = {}
 local hooks = {}
-local fake_gettable = {}
 
 local function Add( event, id, callback )
 
@@ -41,36 +40,36 @@ local function Remove( event, id )
 end
 
 local function Call( event, ... )
-	
+
 	local before = javascript_call
-	
+
 	if not override_callstate then
 		javascript_call = false
 	end
-	
+
 	override_callstate = false
 
 	if not hooks[ event ] then
-		
+
 		javascript_call = before
-		
+
 		return
 	end
 
 	for k, v in pairs( hooks[ event ] ) do
-		
+
 		local success, err = pcall( v, ... )
-		
+
 		if not success then
-			
+
 			print( err )
 
 			hooks[ event ][ k ] = nil -- Even remove persistent hooks
-			
+
 		end
 
 	end
-	
+
 	javascript_call = before
 
 end
@@ -81,10 +80,15 @@ local function GetTable()
 
 	for k, v in pairs( hooks ) do
 
-		ret[ k ] = v
+		ret[ k ] = {};
+		for name in pairs(v) do
+
+			table.insert( ret[ k ], name )
+
+		end
 
 	end
-	
+
 	return ret
 
 end
@@ -96,29 +100,23 @@ local function StopPersist()
 end
 
 local function CalledFromSandbox()
-	
-	return not javascript_call
-	
-end
 
-local function GetUniqueCallID()
-	
-	return unique_call_id
-	
+	return not javascript_call
+
 end
 
 -- called from javascript
 
 function HookCall( event, ... )
-	
+
 	override_callstate = true
-	
+
 	javascript_call = true
-	
+
 	Call ( event, ... )
-	
+
 	javascript_call = false
-	
+
 end
 
 return {


### PR DESCRIPTION
only returns keys, in an array

this is to combat individual hooks being called even when they aren't supposed to be.